### PR TITLE
Hi, I'm new to github and hope this is the way it is intended to be used, as this is a realy small fix. 

### DIFF
--- a/src/moderation/managers.py
+++ b/src/moderation/managers.py
@@ -38,9 +38,7 @@ class ModerationObjectsManager(Manager):
                 # We cannot use dict.get() here!
                 mobject = mobjects[obj.pk] if obj.pk in mobjects\
                 else obj.moderated_object
-                # TODO: Pass a proper fields_exclude \
-                # TODO (self.moderator.fields_exclude)
-                obj_changed = mobject.has_object_been_changed(obj, [])
+                obj_changed = mobject.has_object_been_changed(obj, None)
 
                 if mobject.moderation_status\
                    in [MODERATION_STATUS_PENDING,


### PR DESCRIPTION
Passing None as proper fields_exclude, as self.moderator.fields_exclude is the default anyway.
Fixes Problems with fields that change in the database witout user interaction like timestamps etc.

I started to use django moderation yesterday and noticed that my objects appeard in the site altough they have not been moderated. The reason was a timestamp field in the database, wich seem to change after the change_object was serialized. Excluding the field did not work, so I started debugging and finally found your todo and fixed it. The unit tests are still passing.
