### PR TITLE
docs fix for DJANGO_MODERATION_MODERATORS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -391,8 +391,8 @@ with data from changed_object.::
 Settings
 ========
 
-``MODERATORS``
-    List of moderators e-mails to which notifications will be send.
+``DJANGO_MODERATION_MODERATORS``
+    Tuple of moderators' email addresses to which notifications will be sent.
 
 
 How to run django-moderation tests


### PR DESCRIPTION
This is a quick change in the README to let users know that DJANGO_MODERATION_MODERATORS should be used, not MODERATORS. Would eliminate issues like [61](https://github.com/dominno/django-moderation/issues/61).
