### PR TITLE
Admin customization on moderated models

### DIFF
--- a/src/moderation/admin.py
+++ b/src/moderation/admin.py
@@ -40,7 +40,7 @@ class ModerationAdmin(admin.ModelAdmin):
 
     def get_form(self, request, obj=None):
         if obj and self.admin_integration_enabled:
-            return self.get_moderated_object_form(obj.__class__)
+            self.form = self.get_moderated_object_form(obj.__class__)
 
         return super(ModerationAdmin, self).get_form(request, obj)
 


### PR DESCRIPTION
When adding an object, the fields work as specified in the ModelAdmin. But when I edit them, they don't work, like for example filter_horizontal, etc. You think my solution has any side effect?
