### PR TITLE
Make sure approve works with `auto_now` date fields

### DIFF
--- a/moderation/models.py
+++ b/moderation/models.py
@@ -165,8 +165,8 @@ class ModeratedObject(models.Model):
                 setattr(self.changed_object, self.moderator.visibility_column,
                         True)
 
-            self.save()
             self.changed_object.save()
+            self.save()
 
         else:
             self.save()


### PR DESCRIPTION
If you register a model that has a `DateField` or `DateTimeField` with attribute `auto_now` set to True. The Approve method does not work.

**Reason:**

As in `moderation.models.ModeratedObject._moderate()` method we call the `save` on `moderated_object` first and then on the `changed_object`. Once the `save` method is called on the `changed_object` it updates the `DateField` or `DateTimeField` that has `auto_now` set to `True` which again puts the `changed_object` in to pending state.

**Fix:**

Call the `changed_object`'s save method before calling `moderated_object`'s save method.

**Workaround:**

Put any such `DateField` or `DateTimeField` in `fields_exclude` list.

This pull request makes sure the call to the `save` method for a changed_object is made before calling the `save` method of a `moderated_object`.
