### PR TITLE
Default manager should never return unapproved objects

### DIFF
--- a/moderation/managers.py
+++ b/moderation/managers.py
@@ -41,12 +41,9 @@ class ModerationObjectsManager(Manager):
                 # We cannot use dict.get() here!
                 mobject = mobjects[obj.pk] if obj.pk in mobjects else \
                     obj.moderated_object
-                obj_changed = mobject.has_object_been_changed(obj, None)
 
-                if mobject.moderation_status\
-                   in [MODERATION_STATUS_PENDING,
-                       MODERATION_STATUS_REJECTED] and \
-                   not obj_changed:
+                if mobject.moderation_status == MODERATION_STATUS_PENDING and \
+                   not mobject.moderation_date:
                     exclude_pks.append(obj.pk)
             except ObjectDoesNotExist:
                 pass

--- a/tests/tests/unit/managers.py
+++ b/tests/tests/unit/managers.py
@@ -61,6 +61,7 @@ class ModerationObjectsManagerTestCase(TestCase):
         doesn't have moderated object or deserialized object is <> object"""
         moderated_object = ModeratedObject(content_object=self.profile)
         moderated_object.save()
+        moderated_object.approve()
 
         self.profile.description = "New"
         self.profile.save()

--- a/tests/tests/unit/models.py
+++ b/tests/tests/unit/models.py
@@ -213,12 +213,16 @@ class ModerateTestCase(TestCase):
                          MODERATION_STATUS_REJECTED)
 
     def test_has_object_been_changed_should_be_true(self):
-        self.profile.description = 'New description'
-
+        self.profile.description = 'Old description'
         moderated_object = ModeratedObject(content_object=self.profile)
         moderated_object.save()
+        moderated_object.approve(moderated_by=self.user)
 
         user_profile = UserProfile.objects.get(user__username='moderator')
+
+        self.profile.description = 'New description'
+        moderated_object = ModeratedObject(content_object=self.profile)
+        moderated_object.save()
 
         value = moderated_object.has_object_been_changed(user_profile)
 
@@ -376,12 +380,16 @@ class ModerateCustomUserTestCase(TestCase):
                          MODERATION_STATUS_REJECTED)
 
     def test_has_object_been_changed_should_be_true(self):
-        self.profile.description = 'New description'
-
+        self.profile.description = 'Old description'
         moderated_object = ModeratedObject(content_object=self.profile)
         moderated_object.save()
+        moderated_object.approve(moderated_by=self.user)
 
         user_profile = self.profile.__class__.objects.get(id=self.profile.id)
+
+        self.profile.description = 'New description'
+        moderated_object = ModeratedObject(content_object=self.profile)
+        moderated_object.save()
 
         value = moderated_object.has_object_been_changed(user_profile)
 

--- a/tests/tests/unit/register.py
+++ b/tests/tests/unit/register.py
@@ -69,6 +69,9 @@ class RegistrationTestCase(TestCase):
             when existing object is saved, when getting of object returns 
             old version of object"""
         profile = UserProfile.objects.get(user__username='moderator')
+        moderated_object = ModeratedObject(content_object=profile)
+        moderated_object.save()
+        moderated_object.approve(moderated_by=self.user)
 
         profile.description = "New description"
         profile.save()
@@ -508,7 +511,9 @@ class ModerationSignalsTestCase(TestCase):
         signals.post_save.connect(self.moderation.post_save_handler,
                                   sender=UserProfile)
         profile = UserProfile.objects.get(user__username='moderator')
-        ModeratedObject(content_object=profile).save()
+        moderated_object = ModeratedObject(content_object=profile)
+        moderated_object.save()
+        moderated_object.approve(moderated_by=self.user)
 
         profile.description = 'New description of user profile'
         profile.save()


### PR DESCRIPTION
Since there is no explicit field in ModeratedObject that stores whether the
object has ever been approved, use the moderation_date field which is always set
when an object is approved.
