### PR TITLE
Post moderation signal should send the updated instance.

### DIFF
--- a/moderation/models.py
+++ b/moderation/models.py
@@ -192,7 +192,7 @@ class ModeratedObject(models.Model):
         return False
 
     def approve(self, moderated_by=None, reason=None):
-        pre_moderation.send(sender=self.content_object.__class__,
+        pre_moderation.send(sender=self.changed_object.__class__,
                             instance=self.changed_object,
                             status=MODERATION_STATUS_APPROVED)
 
@@ -203,7 +203,7 @@ class ModeratedObject(models.Model):
                              status=MODERATION_STATUS_APPROVED)
 
     def reject(self, moderated_by=None, reason=None):
-        pre_moderation.send(sender=self.content_object.__class__,
+        pre_moderation.send(sender=self.changed_object.__class__,
                             instance=self.changed_object,
                             status=MODERATION_STATUS_REJECTED)
         self._moderate(MODERATION_STATUS_REJECTED, moderated_by, reason)


### PR DESCRIPTION
Since the `pre_moderation` signal was accessing the `self.content_obect.__class__`, the object got populated from DB and was not getting fetched again after moderation, for the `post_moderation` signal.
This was leading the `post_moderation` signal sending the `pre-moderation` state of the `content object`.

This fixes Issue #88
