### PR TITLE
Remove any call to `get_user_model` from the global scope

### DIFF
--- a/example_project/example_app/models.py
+++ b/example_project/example_app/models.py
@@ -5,7 +5,7 @@ from django.contrib import admin
 
 
 class ExampleUserProfile(models.Model):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL)
+    user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'))
     description = models.TextField()
     url = models.URLField()
     
@@ -24,7 +24,7 @@ if VERSION[:2] >= (1, 5):
         height = models.FloatField(blank=True, null=True)
 
     class UserProfileWithCustomUser(models.Model):
-        user = models.ForeignKey(settings.AUTH_USER_MODEL)
+        user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'))
         description = models.TextField()
         url = models.URLField()
 

--- a/moderation/models.py
+++ b/moderation/models.py
@@ -48,16 +48,18 @@ class ModeratedObject(models.Model):
         default=MODERATION_STATUS_PENDING,
         editable=False)
     moderated_by = models.ForeignKey(
-        settings.AUTH_USER_MODEL, blank=True, null=True,
-        editable=False, related_name='moderated_by_set')
+        getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), 
+        blank=True, null=True, editable=False, 
+        related_name='moderated_by_set')
     moderation_date = models.DateTimeField(editable=False, blank=True,
                                            null=True)
     moderation_reason = models.TextField(blank=True, null=True)
     changed_object = SerializedObjectField(serialize_format='json',
                                            editable=False)
     changed_by = models.ForeignKey(
-        settings.AUTH_USER_MODEL, blank=True, null=True,
-        editable=True, related_name='changed_by_set')
+        getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), 
+        blank=True, null=True, editable=True, 
+        related_name='changed_by_set')
 
     objects = ModeratedObjectManager()
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -8,7 +8,7 @@ from django import VERSION
 
 
 class UserProfile(models.Model):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, 
+    user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), 
                              related_name='user_profile_set')
     description = models.TextField()
     url = models.URLField()

--- a/tests/tests/unit/models.py
+++ b/tests/tests/unit/models.py
@@ -304,7 +304,8 @@ class ModerateCustomUserTestCase(TestCase):
             password='aaaa')
         self.copy_m = ModeratedObject.moderated_by
         ModeratedObject.moderated_by = models.ForeignKey(
-            settings.AUTH_USER_MODEL, blank=True, null=True, editable=False,
+            getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), 
+            blank=True, null=True, editable=False,
             related_name='moderated_by_set')
 
         self.profile = UserProfileWithCustomUser.objects.create(


### PR DESCRIPTION
Since it can cause some trouble during django apps installation step.

Cheers
