### PR TITLE
Django 1.6 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ python:
   - "2.6"
   - "2.7"
 env:
-  - DJANGO=1.3.1
+  - DJANGO=1.3.7
   - DJANGO=1.4
   - DJANGO=1.5
+  - DJANGO=1.6.5
 install:
   - pip install -q Django==$DJANGO
   - pip install -q coverage>=3.6

--- a/moderation/admin.py
+++ b/moderation/admin.py
@@ -38,17 +38,23 @@ set_objects_as_pending.short_description = "Set selected moderated objects "\
 class ModerationAdmin(admin.ModelAdmin):
     admin_integration_enabled = True
 
-    def get_form(self, request, obj=None):
+    def get_form(self, request, obj=None, **kwargs):
         if obj and self.admin_integration_enabled:
             self.form = self.get_moderated_object_form(obj.__class__)
 
-        return super(ModerationAdmin, self).get_form(request, obj)
+        return super(ModerationAdmin, self).get_form(request, obj, **kwargs)
 
-    def change_view(self, request, object_id, extra_context=None):
+    def change_view(self, request, object_id, form_url='', extra_context=None):
         if self.admin_integration_enabled:
             self.send_message(request, object_id)
 
-        return super(ModerationAdmin, self).change_view(request, object_id)
+        try:
+            return super(ModerationAdmin, self)\
+                .change_view(request, object_id, form_url=form_url,
+                             extra_context=extra_context)
+        except TypeError:
+            return super(ModerationAdmin, self)\
+                .change_view(request, object_id, extra_context=extra_context)
 
     def send_message(self, request, object_id):
         try:

--- a/moderation/managers.py
+++ b/moderation/managers.py
@@ -3,7 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 
 
-class MetaClass(type):
+class MetaClass(type(Manager)):
 
     def __new__(cls, name, bases, attrs):
         return super(MetaClass, cls).__new__(cls, name, bases, attrs)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 
 version = '0.3.4'
 
-tests_require = ['django>=1.3.7,<1.6', 'django-webtest>=1.5.7,<1.6',
+tests_require = ['django>=1.3.7,<1.7', 'django-webtest>=1.5.7,<1.6',
                  'webtest>=2.0,<2.1', 'mock', 'pillow', 'unittest2', 'ipdb']
 
 # ipython>2 is only supported on Python 2.7+
@@ -37,7 +37,7 @@ setup(name='django-moderation',
       tests_require=tests_require,
       test_suite='runtests.runtests',
       install_requires=[
-          'django>=1.3.7,<1.6',
+          'django>=1.3.7,<1.7',
           'setuptools',
       ],
       zip_safe=False,

--- a/tests/models.py
+++ b/tests/models.py
@@ -98,9 +98,9 @@ class Book(models.Model):
 
 if VERSION[:2] >= (1, 5):
 
-    from django.contrib.auth.models import AbstractUser
+    from django.contrib.auth.models import User
 
-    class CustomUser(AbstractUser):
+    class CustomUser(User):
         date_of_birth = models.DateField(blank=True, null=True)
         height = models.FloatField(blank=True, null=True)
 

--- a/tests/tests/unit/models.py
+++ b/tests/tests/unit/models.py
@@ -2,7 +2,8 @@ from django.test.testcases import TestCase
 from django import VERSION
 from django.db import models
 from django.contrib.auth.models import User, Group
-from django.test.utils import override_settings
+if VERSION >= (1, 4):
+    from django.test.utils import override_settings
 from tests.models import UserProfile,\
     SuperUserProfile, ModelWithSlugField2, ProxyProfile
 from moderation.models import ModeratedObject, MODERATION_STATUS_APPROVED,\
@@ -290,7 +291,9 @@ class AutoModerateTestCase(TestCase):
 
 
 @unittest.skipIf(VERSION[:2] < (1, 5), "Custom auth users require 1.5")
-@override_settings(AUTH_USER_MODEL='tests.CustomUser')
+# Using the decorator is causing problems with Django 1.3, so use
+# the non-decorated version below.
+# @override_settings(AUTH_USER_MODEL='tests.CustomUser')
 class ModerateCustomUserTestCase(TestCase):
 
     def setUp(self):
@@ -401,3 +404,6 @@ class ModerateCustomUserTestCase(TestCase):
         value = moderated_object.has_object_been_changed(self.profile)
 
         self.assertEqual(value, False)
+
+if VERSION >= (1, 5):
+    ModerateCustomUserTestCase = override_settings(AUTH_USER_MODEL='tests.CustomUser')(ModerateCustomUserTestCase)

--- a/tests/urls/default.py
+++ b/tests/urls/default.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import patterns, include, handler500
+try:
+    from django.conf.urls.defaults import patterns, include, handler500
+except ImportError:
+    from django.conf.urls import patterns, include, handler500
 from django.conf import settings
 from django.contrib import admin
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = django1.3-py26, django1.3-py27, django1.4-py26, django1.4-py27, django1.5-py26, django1.5-py27
+envlist = django1.3-py26, django1.3-py27, django1.4-py26, django1.4-py27, django1.5-py26, django1.5-py27, django1.6-py26, django1.6-py27
 
 [testenv]
 commands = python setup.py test
@@ -49,4 +49,16 @@ deps =
 basepython = python2.7
 deps =
     Django==1.5.4
+    {[testenv]deps}
+
+[testenv:django1.6-py26]
+basepython = python2.6
+deps =
+    Django==1.6.4
+    {[testenv]deps}
+
+[testenv:django1.6-py27]
+basepython = python2.7
+deps =
+    Django==1.6.4
     {[testenv]deps}


### PR DESCRIPTION
Fix some of the incompatible changes between Django 1.3 and 1.6
Maintain unit test backwards compatibility

Default.py imports - fix imports to look at new location

moderation/managers MetaClass needs to inherit from type(django.db.models.manager.Manager) instead of type. This is a Django 1.6 change.
See https://stackoverflow.com/questions/21193720/what-happened-in-the-django-1-6-branch-that-affected-how-manager-metaclasses-wor for details

Since Django 1.6 each test is wrapped in a transaction, so if an exception occurs, the transaction is broken and you need to rollback manually. The solution is to wrap the exception code with transaction.atomic(). In those test cases, check that transaction has the 'atomic' attr - if it does use it.

CustomUser extends User instead of AbstractUser in the test models.

Update ModerationAdmin.get_form so that the function prototype matches the super. It was causing problems with 'fields' kwarg missing

Test configs:
Add Django 1.6.5 to travis
Update Django 1.3 to 1.3.7
Add django1.6 targets to tox
