### PR TITLE
Diff - resolve foreign key

### DIFF
--- a/moderation/diff.py
+++ b/moderation/diff.py
@@ -72,7 +72,8 @@ def get_change(model1, model2, field, resolve_foreignkeys=False):
     return change
 
 
-def get_changes_between_models(model1, model2, excludes=[], resolve_foreignkeys=False):
+def get_changes_between_models(model1, model2, excludes=[],
+                               resolve_foreignkeys=False):
     changes = {}
 
     for field in model1._meta.fields:
@@ -82,7 +83,8 @@ def get_changes_between_models(model1, model2, excludes=[], resolve_foreignkeys=
 
             name = "%s__%s" % (model1.__class__.__name__.lower(), field.name)
 
-            changes[name] = get_change(model1, model2, field, resolve_foreignkeys)
+            changes[name] = get_change(model1, model2, field,
+                                       resolve_foreignkeys)
 
     return changes
 

--- a/tests/tests/unit/diff.py
+++ b/tests/tests/unit/diff.py
@@ -134,7 +134,8 @@ class DiffModeratedObjectTestCase(TestCase):
         self.profile = UserProfile.objects.get(user__username='moderator')
 
         changes = get_changes_between_models(moderated_object.changed_object,
-                                             self.profile, resolve_foreignkeys=True)
+                                             self.profile,
+                                             resolve_foreignkeys=True)
 
         self.assertIn("'userprofile__user': Change object: admin - moderator",
                       str(changes))


### PR DESCRIPTION
This is a small change to the diff functions that allows "resolving" a ForeignKey field so that it displays something human-readable instead of whatever the key is.

For example, when the moderated object has a ForeignKey referencing a User, instead of the User's pk being displayed in the diff, the string representation of the User is displayed.
Instead of `1 - 4` being displayed for a change, `admin - moderator` would be displayed.
