### PR TITLE
Simplify ModeratedObject._moderate method.

### DIFF
--- a/moderation/models.py
+++ b/moderation/models.py
@@ -145,34 +145,52 @@ class ModeratedObject(models.Model):
 
         return moderation.get_moderator(model_class)
 
-    def _moderate(self, status, moderated_by, reason):
-        self.moderation_status = status
+    def _moderate(self, new_status, moderated_by, reason):
+        # See register.py pre_save_handler() for the case where the model is
+        # reset to its old values, and the new values are stored in the
+        # ModeratedObject. In such cases, on approval, we should restore the
+        # changes to the base object by saving the one attached to the
+        # ModeratedObject.
+
+        if (self.moderation_status == MODERATION_STATUS_PENDING and
+                new_status == MODERATION_STATUS_APPROVED and
+                not self.moderator.visible_until_rejected):
+            base_object = self.changed_object
+            base_object_force_save = True
+        else:
+            # The model in the database contains the most recent data already,
+            # or we're not ready to approve the changes stored in
+            # ModeratedObject.
+            obj_class = self.changed_object.__class__
+            pk = self.changed_object.pk
+            base_object = obj_class._default_manager.get(pk=pk)
+            base_object_force_save = False
+
+        self.moderation_status = new_status
         self.moderation_date = datetime.datetime.now()
         self.moderated_by = moderated_by
         self.moderation_reason = reason
+        self.save()
 
-        if status == MODERATION_STATUS_APPROVED:
-            if self.moderator.visible_until_rejected:
-                try:
-                    obj_class = self.changed_object.__class__
-                    pk = self.changed_object.pk
-                    unchanged_obj = obj_class._default_manager.get(pk=pk)
-                except obj_class.DoesNotExist:
-                    unchanged_obj = None
-                self.changed_object = unchanged_obj
+        if self.moderator.visibility_column:
+            old_visible = getattr(base_object,
+                                  self.moderator.visibility_column)
 
-            if self.moderator.visibility_column:
-                setattr(self.changed_object, self.moderator.visibility_column,
-                        True)
+            if new_status == MODERATION_STATUS_APPROVED:
+                new_visible = True
+            elif new_status == MODERATION_STATUS_REJECTED:
+                new_visible = False
+            else:  # MODERATION_STATUS_PENDING
+                new_visible = self.moderator.visible_until_rejected
 
-            self.save()
-            self.changed_object.save()
+            if new_visible != old_visible:
+                setattr(base_object, self.moderator.visibility_column,
+                        new_visible)
+                base_object_force_save = True
 
-        else:
-            self.save()
-        if status == MODERATION_STATUS_REJECTED and\
-           self.moderator.visible_until_rejected:
-            self.changed_object.save()
+        if base_object_force_save:
+            # avoid triggering pre/post_save_handler
+            base_object.save_base(raw=True)
 
         if self.changed_by:
             self.moderator.inform_user(self.content_object, self.changed_by)


### PR DESCRIPTION
The original method was very unclear about what it was doing, and also
saved the base object more often than was necessary. I added a lot of comments
to explain what's happening, and restructured the code so that the variables
and the reasons for following certain branches are clearer and the code is
more readable in my view.

I also avoid calling self.changed_object.save(), and call save_base(raw=True)
instead to avoid triggering the pre_save and post_save hooks again, which would
re-moderate the object.
