### PR TITLE
Hide rejected objects if never approved.

### DIFF
--- a/moderation/admin.py
+++ b/moderation/admin.py
@@ -5,9 +5,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import urlresolvers
 import django
 
-from moderation.models import ModeratedObject, MODERATION_DRAFT_STATE,\
-    MODERATION_STATUS_PENDING, MODERATION_STATUS_REJECTED,\
-    MODERATION_STATUS_APPROVED
+from moderation.models import ModeratedObject, MODERATION_STATUS_PENDING,\
+    MODERATION_STATUS_REJECTED, MODERATION_STATUS_APPROVED
 
 from django.utils.translation import ugettext as _
 from moderation.forms import BaseModeratedObjectForm
@@ -137,11 +136,6 @@ class ModeratedObjectAdmin(admin.ModelAdmin):
 
     def content_object(self, obj):
         return str(obj.changed_object)
-
-    def queryset(self, request):
-        qs = super(ModeratedObjectAdmin, self).queryset(request)
-
-        return qs.exclude(moderation_state=MODERATION_DRAFT_STATE)
 
     def get_moderated_object_form(self, model_class):
 

--- a/moderation/managers.py
+++ b/moderation/managers.py
@@ -19,7 +19,7 @@ class ModerationObjectsManager(Manager):
             {'use_for_related_fields': True})
 
     def filter_moderated_objects(self, query_set):
-        from moderation.models import MODERATION_STATUS_PENDING
+        from moderation.models import MODERATION_READY_STATE
 
         exclude_pks = []
 
@@ -42,8 +42,7 @@ class ModerationObjectsManager(Manager):
                 mobject = mobjects[obj.pk] if obj.pk in mobjects else \
                     obj.moderated_object
 
-                if mobject.moderation_status == MODERATION_STATUS_PENDING and \
-                   not mobject.moderation_date:
+                if mobject.moderation_state != MODERATION_READY_STATE:
                     exclude_pks.append(obj.pk)
             except ObjectDoesNotExist:
                 pass

--- a/moderation/migrations/0001_initial.py
+++ b/moderation/migrations/0001_initial.py
@@ -22,7 +22,7 @@ class Migration(SchemaMigration):
             ('content_type', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['contenttypes.ContentType'], null=True, blank=True)),
             ('object_pk', self.gf('django.db.models.fields.PositiveIntegerField')(null=True, blank=True)),
             ('date_created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
-            ('moderation_state', self.gf('django.db.models.fields.SmallIntegerField')(default=0)),
+            ('moderation_state', self.gf('django.db.models.fields.SmallIntegerField')(default=1)),  # draft state
             ('moderation_status', self.gf('django.db.models.fields.SmallIntegerField')(default=2)),
             ('moderated_by', self.gf('django.db.models.fields.related.ForeignKey')(blank=True, related_name='moderated_by_set', null=True, to=orm[USER_MODEL])),
             ('moderation_date', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),

--- a/moderation/models.py
+++ b/moderation/models.py
@@ -42,7 +42,7 @@ class ModeratedObject(models.Model):
     date_updated = models.DateTimeField(auto_now=True,
                                         default=datetime.datetime.now)
     moderation_state = models.SmallIntegerField(choices=MODERATION_STATES,
-                                                default=MODERATION_READY_STATE,
+                                                default=MODERATION_DRAFT_STATE,
                                                 editable=False)
     moderation_status = models.SmallIntegerField(
         choices=STATUS_CHOICES,
@@ -168,6 +168,11 @@ class ModeratedObject(models.Model):
             pk = self.changed_object.pk
             base_object = obj_class._default_manager.get(pk=pk)
             base_object_force_save = False
+
+        if new_status == MODERATION_STATUS_APPROVED:
+            # This version is now approved, and will be reverted to if
+            # future changes are rejected by a moderator.
+            self.moderation_state = MODERATION_READY_STATE
 
         self.moderation_status = new_status
         self.moderation_date = datetime.datetime.now()

--- a/moderation/register.py
+++ b/moderation/register.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from django.utils.six import with_metaclass
 from moderation.models import ModeratedObject, MODERATION_STATUS_PENDING,\
-    MODERATION_STATUS_APPROVED
+    MODERATION_STATUS_APPROVED, MODERATION_DRAFT_STATE
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.contenttypes import generic
 from moderation.moderator import GenericModerator
@@ -229,6 +229,9 @@ class ModerationManager(with_metaclass(ModerationManagerSingleton, object)):
         if kwargs['created']:
             old_object = sender._default_manager.get(pk=pk)
             moderated_obj = ModeratedObject(content_object=old_object)
+            if not moderator.visible_until_rejected:
+                # Hide it by placing in draft state
+                moderated_obj.moderation_state = MODERATION_DRAFT_STATE
             moderated_obj.save()
             moderator.inform_moderator(instance)
             return

--- a/tests/tests/unit/admin.py
+++ b/tests/tests/unit/admin.py
@@ -10,8 +10,8 @@ from moderation.admin import ModerationAdmin, approve_objects, reject_objects,\
 from tests.utils.testcases import WebTestCase
 from moderation.moderator import GenericModerator
 from moderation.models import ModeratedObject,\
-    MODERATION_DRAFT_STATE, MODERATION_STATUS_APPROVED,\
-    MODERATION_STATUS_REJECTED, MODERATION_STATUS_PENDING
+    MODERATION_STATUS_APPROVED, MODERATION_STATUS_REJECTED,\
+    MODERATION_STATUS_PENDING
 from tests.models import UserProfile, Book, \
     ModelWithSlugField, ModelWithSlugField2, SuperUserProfile
 from tests.utils import setup_moderation, teardown_moderation
@@ -99,11 +99,6 @@ class AdminActionsTestCase(TestCase):
 
     def tearDown(self):
         teardown_moderation()
-
-    def test_queryset_should_return_only_moderation_ready_objects(self):
-        qs = self.admin.queryset(self.request)
-        qs = qs.filter(moderation_state=MODERATION_DRAFT_STATE)
-        self.assertEqual(list(qs), [])
 
     def test_approve_objects(self):
         approve_objects(self.admin, self.request, self.moderated_objects)

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -21,9 +21,10 @@ def setup_moderation(models=[]):
     for model in models:
         try:
             model_class, generic_moderator = model
-            moderation.register(model_class, generic_moderator)
         except TypeError:
             moderation.register(model)
+        else:
+            moderation.register(model_class, generic_moderator)
 
     return moderation
 


### PR DESCRIPTION
The old behaviour is that rejected objects will always be displayed in
querysets, which is weird.

In my view, if an object has never been approved, it should be hidden. If
it has been approved, but a change to it is rejected, then the change should
be reverted and the object should continue to be visible, as it was when it
was approved.

This patch implements that behaviour by using the undocumented
moderation_state column to put objects that have never been approved into
DRAFT state, which hides them from the public but allows the admin to see
them. Once an object has been approved once, its state becomes READY, and
rejections don't change it back to DRAFT, they simply undo the changes.

Note that this changes the behaviour of the moderation_state field slightly.
In particular, the admin will be invited to moderate objects in DRAFT state,
which previously they were not.
