### PR TITLE
added ModeratedModel, fixes #128

### DIFF
--- a/moderation/db.py
+++ b/moderation/db.py
@@ -7,13 +7,13 @@ from django.db.models import base
 class ModeratedModelBase(type):
     def __init__(cls, name, bases, clsdict):
         super(ModeratedModelBase, cls).__init__(name, bases, clsdict)
-        
+
         if (any(x.__name__ == 'ModeratedModel' for x in cls.mro()[1:])):
             moderation.register(cls)
 
 
 class ModelBase(ModeratedModelBase, base.ModelBase):
-    pass 
+    pass
 
 
 class ModeratedModel(six.with_metaclass(ModelBase, base.Model)):

--- a/moderation/db.py
+++ b/moderation/db.py
@@ -1,0 +1,20 @@
+import six
+
+from . import moderation
+from django.db.models import base
+
+
+class ModeratedModelBase(type):
+    def __init__(cls, name, bases, clsdict):
+        super(ModeratedModelBase, cls).__init__(name, bases, clsdict)
+        
+        if (any(x.__name__ == 'ModeratedModel' for x in cls.mro()[1:])):
+            moderation.register(cls)
+
+
+class ModelBase(ModeratedModelBase, base.ModelBase):
+    pass 
+
+
+class ModeratedModel(six.with_metaclass(ModelBase, base.Model)):
+    pass

--- a/tests/tests/unit/models.py
+++ b/tests/tests/unit/models.py
@@ -434,7 +434,7 @@ class ModerateCustomUserTestCase(ModerateTestCase):
             password='aaaa')
         self.copy_m = ModeratedObject.moderated_by
         ModeratedObject.moderated_by = models.ForeignKey(
-            getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), 
+            getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
             blank=True, null=True, editable=False,
             related_name='moderated_by_set')
 
@@ -455,17 +455,18 @@ if VERSION >= (1, 5):
         AUTH_USER_MODEL='tests.CustomUser'
     )(ModerateCustomUserTestCase)
 
-    
+
 class ModeratedModelTestCase(TestCase):
     def setUp(self):
         self.moderation = ModerationManager()
 
     def tearDown(self):
         teardown_moderation()
-       
+
     def test_moderatedmodel_automatic_registration(self):
         class MyTestModel(ModeratedModel):
             pass
-        
-        is_registered = self.moderation._registered_models.get(MyTestModel, None) is not None
+
+        registered_models = self.moderation._registered_models
+        is_registered = registered_models.get(MyTestModel, None) is not None
         self.assertEqual(is_registered, True)

--- a/tests/tests/unit/models.py
+++ b/tests/tests/unit/models.py
@@ -15,6 +15,7 @@ from moderation.register import ModerationManager, RegistrationError
 from moderation.managers import ModerationObjectsManager
 from moderation.moderator import GenericModerator
 from moderation.helpers import automoderate
+from moderation.db import ModeratedModel
 from tests.utils import setup_moderation, teardown_moderation
 from tests.utils import unittest
 
@@ -453,3 +454,18 @@ if VERSION >= (1, 5):
     ModerateCustomUserTestCase = override_settings(
         AUTH_USER_MODEL='tests.CustomUser'
     )(ModerateCustomUserTestCase)
+
+    
+class ModeratedModelTestCase(TestCase):
+    def setUp(self):
+        self.moderation = ModerationManager()
+
+    def tearDown(self):
+        teardown_moderation()
+       
+    def test_moderatedmodel_automatic_registration(self):
+        class MyTestModel(ModeratedModel):
+            pass
+        
+        is_registered = self.moderation._registered_models.get(MyTestModel, None) is not None
+        self.assertEqual(is_registered, True)


### PR DESCRIPTION
Adds `moderation.db.ModeratedModel`.

Models declared with the following syntax:

```python
class MyModel(ModeratedModel):
    pass
```

will be automatically registered.