### PR TITLE
In Django 1.8, ModelForms must define either fields or exclude

### DIFF
--- a/moderation/forms.py
+++ b/moderation/forms.py
@@ -3,9 +3,13 @@ from django.forms.models import ModelForm, model_to_dict
 from moderation.models import MODERATION_STATUS_PENDING,\
     MODERATION_STATUS_REJECTED
 from django.core.exceptions import ObjectDoesNotExist
+from moderation.utils import django_17
 
 
 class BaseModeratedObjectForm(ModelForm):
+    class Meta:
+        if django_17():
+            exclude = '__all__'
 
     def __init__(self, *args, **kwargs):
         instance = kwargs.get('instance', None)


### PR DESCRIPTION
See title. 

FYI, this error was not detected by the tests. I suspect it's because no test tries to *render* a class derived from `BaseModeratedObjectForm`.