### PR TITLE
Enhanced ModeratedModel: embedded Moderator support

### DIFF
--- a/moderation/db.py
+++ b/moderation/db.py
@@ -1,23 +1,82 @@
-from django.utils import six
+"""
+    This module enables automatic Model registration with custom Moderators
+
+    usage example:
+
+        class MyModel(ModeratedModel):
+            desc = models.TextField()
+
+            class Moderator:
+                notify_user = False
+
+"""
+import inspect
+
+from django.utils.six import with_metaclass
+from django.db.models import base
 
 from moderation.register import ModerationManager
-from django.db.models import base
+from moderation.moderator import GenericModerator
 
 moderation = ModerationManager()
 
+
 class ModeratedModelBase(type):
+    """
+    Metaclass for the ``ModeratedModel`` type
+
+        -- automatically registers ``ModeratedModel's``
+        -- resolves subclass ``Moderator`` into
+           a instance of ``GenericModerator``
+
+    """
+    def _resolve_moderator(cls):
+        """
+        ``ModeratedModel`` that defines the class Moderator
+        will have that class resolved into
+        a class derived from ``GenericModerator``
+
+        usage example:
+
+        class MyModel(ModeratedModel):
+            desc = models.TextField()
+
+            # ``Moderator`` below will extend ``GenericModerator``
+            # and will be used when the ``Model`` is registered
+            class Moderator:
+                notify_user = False
+
+        """
+        if hasattr(cls, 'Moderator') and inspect.isclass(cls.Moderator):
+            Moderator = cls.Moderator
+
+            return type(
+                '%sModerator' % cls.__name__,
+                (GenericModerator,),
+                Moderator.__dict__
+            )
+        else:
+            return None
+
     def __init__(cls, name, bases, clsdict):
+        """
+        Registers ``ModeratedModel``
+
+        """
         super(ModeratedModelBase, cls).__init__(name, bases, clsdict)
 
         if (any(x.__name__ == 'ModeratedModel' for x in cls.mro()[1:])):
-            moderation.register(cls)
+            moderation.register(cls, cls._resolve_moderator())
 
 
 class ModelBase(ModeratedModelBase, base.ModelBase):
-    pass
+    """
+    Common metaclass for ``ModeratedModel`` enabling it to inherit
+    the behavior of django ``Model`` objects
+
+    """
 
 
-class ModeratedModel(six.with_metaclass(ModelBase, base.Model)):
-
+class ModeratedModel(with_metaclass(ModelBase, base.Model)):
     class Meta:
         abstract = True

--- a/moderation/db.py
+++ b/moderation/db.py
@@ -1,8 +1,9 @@
-import six
+from django.utils import six
 
-from . import moderation
+from moderation.register import ModerationManager
 from django.db.models import base
 
+moderation = ModerationManager()
 
 class ModeratedModelBase(type):
     def __init__(cls, name, bases, clsdict):

--- a/moderation/utils.py
+++ b/moderation/utils.py
@@ -2,7 +2,29 @@ import django
 from distutils.version import StrictVersion
 
 
+def clear_builtins(attrs):
+    """
+    Clears the builtins from an ``attrs`` dict
+
+    Returns a new dict without the builtins
+
+    """
+    new_attrs = {}
+
+    for key in attrs.keys():
+        if not(key.startswith('__') and key.endswith('__')):
+            new_attrs[key] = attrs[key]
+
+    return new_attrs
+
+
 def django_17():
     if StrictVersion(django.get_version()) >= StrictVersion('1.7.0'):
+        return True
+    return False
+
+
+def django_14():
+    if StrictVersion(django.get_version()) < StrictVersion('1.5.0'):
         return True
     return False

--- a/tests/more_models.py
+++ b/tests/more_models.py
@@ -8,3 +8,7 @@ class MyTestModel(ModeratedModel):
     class Moderator:
         notify_user = False
         made_up_value = 'made_up'
+
+
+class MyTestModelWithoutModerator(ModeratedModel):
+    name = models.CharField(max_length=20)

--- a/tests/more_models.py
+++ b/tests/more_models.py
@@ -4,3 +4,7 @@ from moderation.db import ModeratedModel
 
 class MyTestModel(ModeratedModel):
     name = models.CharField(max_length=20)
+
+    class Moderator:
+        notify_user = False
+        made_up_value = 'made_up'

--- a/tests/tests/unit/testmodels.py
+++ b/tests/tests/unit/testmodels.py
@@ -455,8 +455,10 @@ if VERSION >= (1, 5):
     )(ModerateCustomUserTestCase)
 
 
-@unittest.skipIf(VERSION[:2] < (1, 5),
-    "django.utils.six.with_metaclass does not work properly until 1.5")
+@unittest.skipIf(
+    VERSION[:2] < (1, 5),
+    "django.utils.six.with_metaclass does not work properly until 1.5"
+)
 class ModeratedModelTestCase(TestCase):
 
     def tearDown(self):

--- a/tests/tests/unit/testmodels.py
+++ b/tests/tests/unit/testmodels.py
@@ -466,9 +466,11 @@ class ModeratedModelTestCase(TestCase):
 
     def test_moderatedmodel_automatic_registration(self):
         from tests.more_models import MyTestModel
+        from tests.more_models import MyTestModelWithoutModerator
         from moderation import moderation
 
         registered_models = moderation._registered_models
+        # test registration with moderator
         moderator = registered_models.get(MyTestModel, None)
         is_registered = moderator is not None
         self.assertEqual(is_registered, True)
@@ -478,3 +480,19 @@ class ModeratedModelTestCase(TestCase):
         # the value added to the Moderator should also show up
         made_up_value = moderator.made_up_value
         self.assertEqual(made_up_value, 'made_up')
+
+        # test registration without custom moderator
+        moderator = registered_models.get(MyTestModelWithoutModerator)
+        self.assertEqual(
+            moderator.__class__.__name__,
+            'GenericModerator'
+        )
+
+    def test_django_14(self):
+        # django_14 test
+        from mock import patch, Mock
+        from moderation.utils import django_14
+        version = Mock()
+        version.return_value = '1.4.8'
+        with patch('django.get_version', version):
+            self.assertTrue(django_14())

--- a/tests/tests/unit/testmodels.py
+++ b/tests/tests/unit/testmodels.py
@@ -455,7 +455,10 @@ if VERSION >= (1, 5):
     )(ModerateCustomUserTestCase)
 
 
+@unittest.skipIf(VERSION[:2] < (1, 5),
+    "django.utils.six.with_metaclass does not work properly until 1.5")
 class ModeratedModelTestCase(TestCase):
+
     def tearDown(self):
         teardown_moderation()
 
@@ -465,9 +468,9 @@ class ModeratedModelTestCase(TestCase):
 
         registered_models = moderation._registered_models
         moderator = registered_models.get(MyTestModel, None)
-        is_registered = registered_models.get(MyTestModel, None) is not None
+        is_registered = moderator is not None
         self.assertEqual(is_registered, True)
-        # if Moderator extended then default setting should be overwritten
+        # if Moderator extended then default notify_user should be overwritten
         notify_user = moderator.notify_user
         self.assertEqual(notify_user, False)
         # the value added to the Moderator should also show up

--- a/tests/tests/unit/testmodels.py
+++ b/tests/tests/unit/testmodels.py
@@ -464,5 +464,12 @@ class ModeratedModelTestCase(TestCase):
         from moderation import moderation
 
         registered_models = moderation._registered_models
+        moderator = registered_models.get(MyTestModel, None)
         is_registered = registered_models.get(MyTestModel, None) is not None
         self.assertEqual(is_registered, True)
+        # if Moderator extended then default setting should be overwritten
+        notify_user = moderator.notify_user
+        self.assertEqual(notify_user, False)
+        # the value added to the Moderator should also show up
+        made_up_value = moderator.made_up_value
+        self.assertEqual(made_up_value, 'made_up')


### PR DESCRIPTION
This PR extends the functionality of ``ModeratedModel`` by enabling embedded  definitions of ``Moderator`` options. The ``Moderator`` options that will be attached to the ``ModeratedModel`` can now be defined inside the class definition in the following fashion:

```python
class MyModel(ModeratedModel):
    desc = models.TextField()

    class Moderator:
        notify_user = False
```
The ``Moderator`` class will be discovered prior to registration and its attributes shall be used to overwrite the default values in the ``GenericModerator``

This essentially makes the need for separate ``Moderator`` definition, explicit ``Model`` registration and ``auto_discovery`` obsolete.