### PR TITLE
Update README and documentation

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -172,3 +172,49 @@ new version will be saved in moderated_object:
     your_model = YourModel.objects.get(pk=1)
     your_model.__dict__
     {'id': 1, 'description': 'New description'}
+
+
+Upgrading From Previous Versions of Django ModerationAdmin
+----------------------------------------------------------
+
+Upgrading from previous versions of django-moderation will require converting from South migrations to Django 1.7+ migrations.
+
+To do so, you will need to perform the following steps (skip any you have already done):
+
+1. Configure South to use the `migrations-pre17` directory for django-moderation migrations:
+
+    .. code-block:: python
+
+        SOUTH_MIGRATION_MODULES = {
+            'moderation': 'moderation.migrations-pre17',
+        }
+
+2. Use South to migrate up to ``0002`` in the ``migrations-pre17`` directory:
+
+    .. code-block:: bash
+
+        python manage.py syncdb moderation 0001  # Skip this if already applied
+        python manage.py syncdb moderation 0002  # Skip this if already applied
+
+
+3. Fake the first two Django migrations:
+
+    .. code-block:: bash
+
+        python manage.py migrate moderation 0001 --fake
+        python manage.py migrate moderation 0002 --fake
+
+4. Use Django to migrate ``0003``:
+
+    .. code-block:: bash
+
+        python manage.py migrate moderation 0003
+
+5. Finally, remove the settings for South:
+
+    .. code-block:: python
+
+        SOUTH_MIGRATION_MODULES = {
+            # 'moderation': 'moderation.migrations-pre17',
+        }
+

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -80,4 +80,20 @@ Added features
 - Dropped support for django 1.3
 - Added support for ForeignKey relations
 
+0.4.0 (2016-08-25)
+------------------
+
+- Updated to support Django 1.7 - 1.9
+- Added instructions for switching from South migrations to Django 1.7+ migrations
+- Improved filter logic for Django 1.8+ to only create one additional query per queryset, instead of N additional queries (eg: one additional query per object in the querset)
+- Renamed model fields to be shorter, less redundant, and more semantically correct
+- Modified registry to add a ``moderation_status`` shortcut to registered models
+- Added support for moderating multiple objects at once
+- Changed model choice fields to use ``Choices`` from django-model-utils
+- Deprecated the ``DJANGO_MODERATION_MODERATORS`` setting in favor of ``MODERATION_MODERATORS``, which does the same thing
+- Improved default email template formatting
+- PEP8 and Flake Fixups
+- Internal code and documentation typo fixes
+- Bug fixes (specifically, closes #87)
+
 


### PR DESCRIPTION
Add instructions for switching between South migrations and Django 1.7+ migrations, and update `history.rst`.