### PR TITLE
Django 1.10 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,14 @@ python:
   - "3.4"
   - "3.5"
 env:
-  - DJANGO=1.7.11
   - DJANGO=1.8.14
   - DJANGO=1.9.9
-  # - DJANGO=1.10
+  - DJANGO=1.10
+  - DJANGO=1.11
 matrix:
   exclude:
-    - python: "3.5"
-      env: DJANGO=1.7.11
     - python: "3.3"
       env: DJANGO=1.9.9
-    # - python: "3.3"
-    #   env: DJANGO=1.10
 install:
   - pip install -q Django==$DJANGO
   - pip install -q coverage>=3.6

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Requirements
 
 python 2.7, 3.3+
 
-django >= 1.7, < 1.10
+django >= 1.8, <= 1.10
 
 django-model-utils
 
@@ -49,9 +49,7 @@ django-model-utils
 Known issues
 ============
 
-- No Django 1.10 support yet
 - m2m relations in models are not currently supported
-- For Django 1.7, a query is run for every object in a query, resulting in N+1 total queries. For Django >= 1.8 only one additional query is run for each unmoderated query.
 
 
 Documentation

--- a/moderation/__init__.py
+++ b/moderation/__init__.py
@@ -22,4 +22,5 @@ class _ModerationProxy(object):
         self._ensure_obj()
         return setattr(_ModerationProxy._moderation, attribute, value)
 
+
 moderation = _ModerationProxy()

--- a/moderation/admin.py
+++ b/moderation/admin.py
@@ -31,6 +31,7 @@ def approve_objects(modeladmin, request, queryset):
     for obj in queryset:
         obj.approve(by=request.user)
 
+
 approve_objects.short_description = _("Approve selected moderated objects")
 
 
@@ -38,11 +39,13 @@ def reject_objects(modeladmin, request, queryset):
     for obj in queryset:
         obj.reject(by=request.user)
 
+
 reject_objects.short_description = _("Reject selected moderated objects")
 
 
 def set_objects_as_pending(modeladmin, request, queryset):
     queryset.update(status=MODERATION_STATUS_PENDING)
+
 
 set_objects_as_pending.short_description = _("Set selected moderated"
                                              " objects as Pending")

--- a/moderation/db.py
+++ b/moderation/db.py
@@ -80,6 +80,7 @@ class ModelBase(ModeratedModelBase, base.ModelBase):
 
     """
 
+
 if not django_14():
     # django.utils.six.with_metaclass is broken in django < 1.5
     class ModeratedModel(with_metaclass(ModelBase, base.Model)):

--- a/moderation/utils.py
+++ b/moderation/utils.py
@@ -18,6 +18,12 @@ def clear_builtins(attrs):
     return new_attrs
 
 
+def django_110():
+    if StrictVersion(django.get_version()) >= StrictVersion('1.10.0'):
+        return True
+    return False
+
+
 def django_19():
     if StrictVersion(django.get_version()) >= StrictVersion('1.9.0'):
         return True

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 version = '0.4.0'
 
 tests_require = [
-    'django>=1.7,<1.10',
+    'django>=1.7,<1.11',
     'django-webtest>=1.5.7-web',
     'webtest>=2.0,<2.1',
     'mock',
@@ -46,7 +46,7 @@ setup(
     tests_require=tests_require,
     test_suite='runtests.runtests',
     install_requires=[
-        'django>=1.7,<1.10',
+        'django>=1.7,<1.11',
         'django-model-utils',
     ],
     zip_safe=False,

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -7,4 +7,5 @@ from .models import Book
 class BookAdmin(ModerationAdmin):
     pass
 
+
 admin.site.register(Book, BookAdmin)

--- a/tests/tests/unit/testmodels.py
+++ b/tests/tests/unit/testmodels.py
@@ -452,6 +452,7 @@ class ModerateCustomUserTestCase(ModerateTestCase):
 
     # The actual tests are inherited from ModerateTestCase
 
+
 if VERSION >= (1, 5):
     ModerateCustomUserTestCase = override_settings(
         AUTH_USER_MODEL='tests.CustomUser'

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,6 @@
 
 [tox]
 envlist = 
-          django1.7-py27,
-          django1.7-py33,
-          django1.7-py34,
           django1.8-py27,
           django1.8-py33,
           django1.8-py34,
@@ -15,9 +12,9 @@ envlist =
           django1.9-py27,
           django1.9-py34,
           django1.9-py35,
-;          django1.10-py27,
-;          django1.10-py34,
-;          django1.10-py35,
+          django1.10-py27,
+          django1.10-py34,
+          django1.10-py35,
 
 [testenv]
 commands = python setup.py test
@@ -25,27 +22,6 @@ commands = python setup.py test
 deps =
     mock
     pillow
-
-[testenv:django1.7-py27]
-basepython = python2.7
-deps =
-    Django==1.7.11
-    unittest2
-    {[testenv]deps}
-
-[testenv:django1.7-py33]
-basepython = python3.3
-deps =
-    Django==1.7.11
-    unittest2py3k
-    {[testenv]deps}
-
-[testenv:django1.7-py34]
-basepython = python3.4
-deps =
-    Django==1.7.11
-    unittest2py3k
-    {[testenv]deps}
 
 [testenv:django1.8-py27]
 basepython = python2.7
@@ -96,23 +72,23 @@ deps =
     unittest2py3k
     {[testenv]deps}
 
-; [testenv:django1.10-py27]
-; basepython = python2.7
-; deps =
-;     Django==1.10
-;     unittest2
-;     {[testenv]deps}
+[testenv:django1.10-py27]
+basepython = python2.7
+deps =
+    Django==1.10
+    unittest2
+    {[testenv]deps}
 
-; [testenv:django1.10-py34]
-; basepython = python3.4
-; deps =
-;     Django==1.10
-;     unittest2py3k
-;     {[testenv]deps}
+[testenv:django1.10-py34]
+basepython = python3.4
+deps =
+    Django==1.10
+    unittest2py3k
+    {[testenv]deps}
 
-; [testenv:django1.10-py35]
-; basepython = python3.5
-; deps =
-;     Django==1.10
-;     unittest2py3k
-;     {[testenv]deps}
+[testenv:django1.10-py35]
+basepython = python3.5
+deps =
+    Django==1.10
+    unittest2py3k
+    {[testenv]deps}


### PR DESCRIPTION
Notably:

- Drops support for Django 1.7
- Still supports Django 1.8, a [Long Term Support release](https://docs.djangoproject.com/en/1.11/releases/1.8/)
- Passed tests fine in the [newly-released Django 1.11](https://docs.djangoproject.com/en/1.11/releases/1.11/) but I didn't want to make any assurances :)
- Makes very superficial changes to the actual codebase, which appears to run fine from @blag's [pull request](https://github.com/dominno/django-moderation/pull/151) in absence of 1.7, [per his comment](https://github.com/dominno/django-moderation/pull/151#issuecomment-286181745). This is a glorified version bump.

I'm relatively new to the project, mostly put this together for expediency, but if there's anything else I can contribute or improve on it, I'm happy to try and accommodate. :)