### PR TITLE
Don't use builtins to get model class

### DIFF
--- a/moderation/models.py
+++ b/moderation/models.py
@@ -152,7 +152,7 @@ class ModeratedObject(models.Model):
 
     @property
     def moderator(self):
-        model_class = self.content_object.__class__
+        model_class = self.content_type.model_class()
 
         return moderation.get_moderator(model_class)
 
@@ -163,7 +163,7 @@ class ModeratedObject(models.Model):
 
         self._moderate(new_status, by, reason)
 
-        post_moderation.send(sender=self.content_object.__class__,
+        post_moderation.send(sender=self.content_type.model_class(),
                              instance=self.content_object,
                              status=new_status)
 


### PR DESCRIPTION
Hey there. With the current project I'm working on, I'm getting some runtime errors with this package, where for some reason `self.content_object` is a `None`.  I think this can happen when you have models that aren't registered with the moderation system (but the class is).

Getting the model class from the content_type feels to me a fair bit safer.