### PR TITLE
django 3.x compatibility with python 3.8 and 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,16 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9"
 env:
   - DJANGO='Django>=1.11,<2.0'
   - DJANGO='Django>=2.0,<2.1'
   - DJANGO='Django>=2.1,<2.2'
   - DJANGO='Django>=2.2,<2.3'
+  - DJANGO='Django>=3.0,<3.1'
+  - DJANGO='Django>=3.1,<3.2'
+  - DJANGO='Django>=3.2,<3.3'
   - DJANGO='https://github.com/django/django/archive/master.tar.gz'
 matrix:
   exclude:

--- a/moderation/register.py
+++ b/moderation/register.py
@@ -1,5 +1,4 @@
 from django.contrib.contenttypes.fields import GenericRelation
-from django.utils.six import with_metaclass
 
 from .constants import (MODERATION_DRAFT_STATE,
                         MODERATION_STATUS_APPROVED,
@@ -26,7 +25,7 @@ class ModerationManagerSingleton(type):
         return cls.instance
 
 
-class ModerationManager(with_metaclass(ModerationManagerSingleton, object)):
+class ModerationManager(metaclass=ModerationManagerSingleton):
     def __init__(self, *args, **kwargs):
         """Initializes the moderation manager."""
         self._registered_models = {}

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ version = __import__('moderation').__version__
 
 tests_require = [
     'unittest2py3k',
-    'django>=1.11,<2.3',
+    'django>=1.11',
     'django-webtest',
     'webtest',
     'mock',
@@ -15,7 +15,7 @@ tests_require = [
 ]
 
 install_requires = [
-    'django>=1.11,<2.3',
+    'django>=1.11',
     'django-model-utils'
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,7 @@
 [tox]
 envlist =
         django{1.11,2.0,2.1}-py{35,36,37},
-        django2.2-py{36,37},
-        django{3.0,3.1,3.2}-py{36,37,38,39},
+        django{2.2,3.0,3.1,3.2}-py{36,37,38,39},
 [testenv]
 commands = python setup.py test
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,18 +5,9 @@
 
 [tox]
 envlist =
-          django1.11-py35,
-          django1.11-py36,
-          django1.11-py37,
-          django2.0-py35,
-          django2.0-py36,
-          django2.0-py37,
-          django2.1-py35,
-          django2.1-py36,
-          django2.1-py37,
-          django2.2-py36,
-          django2.2-py37,
-
+        django{1.11,2.0,2.1}-py{35,36,37},
+        django2.2-py{36,37},
+        django{3.0,3.1,3.2}-py{36,37,38,39},
 [testenv]
 commands = python setup.py test
 


### PR DESCRIPTION
In line with #195 (but without Python syntax diffs in the commits), I am adding compatibility with Django 3.0, 3.1 and 3.2.

Additionally, tests for Django 3.x are also run in Python 3.8 and 3.9.