### PR TITLE
Support only active/secure Django versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ develop-eggs
 dist
 downloads
 eggs
+.eggs
 parts
 *.egg-info
 */example_project.db

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ version = __import__('moderation').__version__
 
 tests_require = [
     'unittest2py3k',
-    'django==2.2,>=3.1',
+    'django~=2.2,>~3.1',
     'django-webtest',
     'webtest',
     'mock',
@@ -15,7 +15,7 @@ tests_require = [
 ]
 
 install_requires = [
-    'django==2.2,>=3.1',
+    'django~=2.2,>~3.1',
     'django-model-utils'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ version = __import__('moderation').__version__
 
 tests_require = [
     'unittest2py3k',
-    'django>=1.11',
+    'django==2.2,>=3.1',
     'django-webtest',
     'webtest',
     'mock',
@@ -15,16 +15,9 @@ tests_require = [
 ]
 
 install_requires = [
-    'django>=1.11',
+    'django==2.2,>=3.1',
     'django-model-utils'
 ]
-
-# override django-model-utils version in requirements file if DJANGO env is set
-DJANGO_ENV = os.environ.get("DJANGO")
-if DJANGO_ENV == 'Django>=1.11,<2.0':
-    install_requires = [
-        "django-model-utils<4" if r == "django-model-utils" else r for r in install_requires
-    ]
 
 setup(
     name='django-moderation',
@@ -46,11 +39,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,8 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist =
-        django{1.11,2.0,2.1}-py{35,36,37},
-        django{2.2,3.0,3.1,3.2}-py{36,37,38,39},
+envlist = django{2.2,3.1,3.2}-py{36,37,38,39},
+
 [testenv]
 commands = python setup.py test
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,12 @@
 
 [tox]
 envlist =
-    django2.2.7-py{3.5,3.6,3.7}
-    django2.2.16-py{3.5,3.6,3.7,3.8}
-    django2.2-py{3.5,3.6,3.7,3.8,3.9}
-    django{3.1,3.2}-py{36,37,38,39},
+    django2.2.7-py{35,36,37}
+    django2.2.16-py{35,36,37,38}
+    django2.2-py{35,36,37,38,39}
+    django3.1.2-py{36,37,38}
+    django3.1-py{36,37,38,39}
+    django3.2-py{36,37,38,39},
 
 
 [testenv]
@@ -21,3 +23,5 @@ deps =
     django2.2.7: Django>=2.2.0,<=2.2.7
     django2.2.16: Django>=2.2.8,<=2.2.16
     django2.2: Django>=2.2.17
+    django3.1.2: Django>=3.1.0,<=3.1.2
+    django3.1: Django>=3.1.3

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = django{2.2,3.1,3.2}-py{36,37,38,39},
+envlist =
+    django2.2.7-py{3.5,3.6,3.7}
+    django2.2.16-py{3.5,3.6,3.7,3.8}
+    django2.2-py{3.5,3.6,3.7,3.8,3.9}
+    django{3.1,3.2}-py{36,37,38,39},
+
 
 [testenv]
 commands = python setup.py test
@@ -13,3 +18,6 @@ deps =
     mock
     pillow
     unittest2py3k
+    django2.2.7: Django>=2.2.0,<=2.2.7
+    django2.2.16: Django>=2.2.8,<=2.2.16
+    django2.2: Django>=2.2.17


### PR DESCRIPTION
Fixed #204

- Python 3.6+ for Django 3.1 as needed (Python 3.9 was added in 3.1.3)
- Python 3.6+ for Django 3.2
- Python 3.5+ for Django 2.2 as needed (some patch versions support Python 3.8 and some also support Python 3.9)
- Django 2.2, 3.1, 3.2 support
- Update [trove classifiers](https://www.python.org/dev/peps/pep-0301/#distutils-trove-classification)
- Update `tox` config
- Additional ignore directory created by `tox`

Python testing based on [Django's 2.2 release notes](https://docs.djangoproject.com/en/3.2/releases/2.2/#python-compatibility):

![image](https://user-images.githubusercontent.com/3974019/129033186-dd066dc6-e92b-46b3-b40e-6ddf8eb3d9c8.png)

What was tested (`tox -l`):

![image](https://user-images.githubusercontent.com/3974019/129038432-f2e94ff4-a0a3-4afb-bd52-d80db8474c66.png)

All tests pass (`tox`):

![image](https://user-images.githubusercontent.com/3974019/129038440-05b5921f-9abe-49e6-979f-4a99b5e92257.png)