### PR TITLE
Update setup.py to allow the use of Django 3.2.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,12 @@
 from setuptools import setup, find_packages
 import os
-import sys
 
 # Dynamically calculate the version based on moderation.VERSION.
 version = __import__('moderation').__version__
 
 tests_require = [
     'unittest2py3k',
-    'django~=2.2,>~3.1',
+    'django>=1.11',
     'django-webtest',
     'webtest',
     'mock',
@@ -15,7 +14,7 @@ tests_require = [
 ]
 
 install_requires = [
-    'django~=2.2,>~3.1',
+    'django>=1.11',
     'django-model-utils'
 ]
 


### PR DESCRIPTION
### What this PR does
- Currently django-moderation fails to install for projects using Django 3.2.*
- I believe this is because the setup.py specifies that we need to use 3.1.*
- As recommend in https://github.com/dominno/django-moderation/pull/195#issuecomment-783614412 I've tweak the pattern to 'django>=1.11'
- I've forked and have tested the project with Django 3.2.7 and it seems to all be working
- If we merge this it would be nice to have a new release too 💪 