### PR TITLE
Better support for Django 3.2.*

### DIFF
--- a/moderation/apps.py
+++ b/moderation/apps.py
@@ -4,6 +4,7 @@ from django.apps import AppConfig
 class SimpleModerationConfig(AppConfig):
     name = 'moderation'
     verbose_name = 'Moderation'
+    default_auto_field = 'django.db.models.AutoField'
 
 
 class ModerationConfig(SimpleModerationConfig):

--- a/runtests.py
+++ b/runtests.py
@@ -55,6 +55,7 @@ if not settings.configured and not os.environ.get('DJANGO_SETTINGS_MODULE'):
         ),
         DEBUG=True,
         SITE_ID=1,
+        SECRET_KEY="dummy",
         # For Django 1.10 compatibility
         # See https://docs.djangoproject.com/en/1.10/ref/settings/#std:setting-TEMPLATES
         TEMPLATES=[

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ tests_require = [
 ]
 
 install_requires = [
-    'django>=1.11',
+    'django>=1.11,<4',
     'django-model-utils'
 ]
 

--- a/tests/apps.py
+++ b/tests/apps.py
@@ -4,3 +4,4 @@ from django.apps import AppConfig
 class TestsAppConfig(AppConfig):
     name = 'tests'
     verbose_name = 'Moderation Tests'
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
### What this PR does

The main purpose is to define the default_auto_field explicitly, in line with the 3.2 release notes here https://docs.djangoproject.com/en/4.0/releases/3.2/#customizing-type-of-auto-created-primary-keys

This prevents an extra migration being required in the event that this app is included in a project which defines a default_auto_field of anything other than 'django.db.models.AutoField'

Perhaps BigAutoField is a better choice here, in which case this app would need to be shipped with the supporting migration - I shall leave that up to the authors, but this should work as is, without changing any existing deployments.

Other changes are limited to strictly those required to support the unit tests passing locally, specifically:
- Restrict supported Django versions in setup.py to <4 due to `ugettext_lazy` having apparently moved in 4.X and hence a failing import
- Adding a dummy secret key to the testing config in `runtests.py`
- Making the analogous change in the `tests/apps.py` for explicitly setting default_auto_field to suppress warnings during test running