### PR TITLE
Drop Django 2.2

### DIFF
--- a/moderation/moderator.py
+++ b/moderation/moderator.py
@@ -12,6 +12,7 @@ from .message_backends import (
     EmailMessageBackend,
     EmailMultipleMessageBackend,
 )
+from .utils import is_sites_framework_enabled
 
 
 class GenericModerator:
@@ -146,9 +147,13 @@ class GenericModerator:
         context = {
             'moderated_object': content_object.moderated_object,
             'content_object': content_object,
-            'site': Site.objects.get_current(),
             'content_type': content_object.moderated_object.content_type,
         }
+
+        if is_sites_framework_enabled():
+            context.update({
+                'site': Site.objects.get_current(),
+            })
 
         if extra_context:
             context.update(extra_context)
@@ -162,9 +167,13 @@ class GenericModerator:
     def send_many(
         self, queryset, subject_template, message_template, extra_context=None
     ):
-        site = Site.objects.get_current()
-
         ctx = extra_context if extra_context else {}
+
+        if is_sites_framework_enabled():
+            site = Site.objects.get_current()
+            ctx.update({
+                'site': site,
+            })
 
         datatuples = tuple(
             {
@@ -174,7 +183,6 @@ class GenericModerator:
                         {
                             'moderated_object': mobj,
                             'content_object': mobj.content_object,
-                            'site': site,
                             'content_type': mobj.content_type,
                             'user': mobj.changed_by,
                         }
@@ -186,7 +194,6 @@ class GenericModerator:
                         {
                             'moderated_object': mobj,
                             'content_object': mobj.content_object,
-                            'site': site,
                             'content_type': mobj.content_type,
                             'user': mobj.changed_by,
                         }

--- a/moderation/utils.py
+++ b/moderation/utils.py
@@ -12,3 +12,11 @@ def clear_builtins(attrs):
             new_attrs[key] = attrs[key]
 
     return new_attrs
+
+
+def is_sites_framework_enabled():
+    """
+    Check project's settings to see if the optional Sites framework is installed.
+    """
+    from django.conf import settings
+    return True if "django.contrib.sites" in settings.INSTALLED_APPS else False

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,13 @@ import os
 version = __import__('moderation').__version__
 
 tests_require = [
-    'django>=2.2',
+    'django>=3.1',
     'django-webtest',
     'webtest',
     'pillow',
 ]
 
-install_requires = ['django>=2.2']
+install_requires = ['django>=3.1']
 
 setup(
     name='django-moderation',
@@ -33,7 +33,6 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
         'Framework :: Django',
-        'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -18,4 +18,5 @@ deps =
     pillow
     django3.1: Django>=3.1,<3.2
     django3.2: Django>=3.2,<4.0
+    django3.2.9: Django>=3.2.9,<4.0
     django4.0: Django>=4.0,<4.1

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,10 @@
 
 [tox]
 envlist =
-    django2.2-py{36,37,38}
     django3.1-py{36,37,38,39}
     django3.2-py{36,37,38,39}
-    django4.0-py{38,39}
+    django3.2.9-py{310}
+    django4.0-py{38,39,310}
 
 
 [testenv]
@@ -16,7 +16,6 @@ commands = python setup.py test
 
 deps =
     pillow
-    django2.2: Django>=2.2,<3.0
     django3.1: Django>=3.1,<3.2
     django3.2: Django>=3.2,<4.0
     django4.0: Django>=4.0,<4.1


### PR DESCRIPTION
* Drop Django 2.2 (EOL).
* Update classifiers.
* Update tox for current versions of Django+Python.

Partially solves #214.

`tox` output:

```
  django3.1-py36: commands succeeded
  django3.1-py37: commands succeeded
  django3.1-py38: commands succeeded
  django3.1-py39: commands succeeded
  django3.2-py36: commands succeeded
  django3.2-py37: commands succeeded
  django3.2-py38: commands succeeded
  django3.2-py39: commands succeeded
  django3.2.9-py310: commands succeeded
  django4.0-py38: commands succeeded
  django4.0-py39: commands succeeded
  django4.0-py310: commands succeeded
  congratulations :)
```